### PR TITLE
Only load default plugins when necessary

### DIFF
--- a/if.py
+++ b/if.py
@@ -5,7 +5,6 @@ import subprocess
 import dotbot
 from dotbot.dispatcher import Dispatcher
 from dotbot.util import module
-from dotbot.plugins import Clean, Create, Link, Shell
 
 
 class If(dotbot.Plugin):
@@ -49,6 +48,7 @@ class If(dotbot.Plugin):
             abspath = os.path.abspath(path)
             plugins.extend(module.load(abspath))
         if not self._context.options().disable_built_in_plugins:
+            from dotbot.plugins import Clean, Create, Link, Shell
             plugins.extend([Clean, Create, Link, Shell])
         return plugins
 


### PR DESCRIPTION
## General Information 
This is for a fix to issue #3. 

We only load the default plugins when necessary.  

## Testing 

For testing I was able to run the config discussed in the issue and received the following result: 
<img width="418" alt="Screenshot 2024-07-14 at 12 04 59 AM" src="https://github.com/user-attachments/assets/5665beda-48f2-48f6-aab6-fe08cece8ffb">

I had also tried to run it with the problematic argument and received an expected error. 
<img width="562" alt="Screenshot 2024-07-14 at 12 07 30 AM" src="https://github.com/user-attachments/assets/f55d990d-7e6d-4c74-aab7-5b62e318c3bd">


## Side note

Admittedly this is not best practice in terms of style, which would require having the imports at the top of the file.  However, this is required due to the way that `dotbot` imports it's plugins.  